### PR TITLE
Final pass at lint cleanup (just size lints remaining)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -806,7 +806,7 @@ fn create_progress_handler(pb: ProgressBar) -> impl FnMut(u64, u64) {
 
 fn print_welcome(term: &mut Term, welcome: Option<&str>) -> eyre::Result<()> {
     if let Some(welcome) = &welcome {
-        writeln!(term, "Got welcome from server: {}", welcome)?;
+        writeln!(term, "Got welcome from server: {welcome}")?;
     }
     Ok(())
 }
@@ -841,7 +841,7 @@ fn sender_print_code(
     } else {
         let qr_code = qr2term::generate_qr_string(&uri)
             .context("Failed to generate QR code for send link")?;
-        writeln!(term, "{}", qr_code)?;
+        writeln!(term, "{qr_code}")?;
     }
 
     writeln!(
@@ -1081,7 +1081,7 @@ async fn receive_inner_v1(
                     "Receive file '{}' ({})?",
                     req.file_name().green().bold(),
                     match NumberPrefix::binary(req.file_size() as f64) {
-                        NumberPrefix::Standalone(bytes) => format!("{} bytes", bytes),
+                        NumberPrefix::Standalone(bytes) => format!("{bytes} bytes"),
                         NumberPrefix::Prefixed(prefix, n) =>
                             format!("{:.1} {}B", n, prefix.symbol()),
                     }
@@ -1092,7 +1092,7 @@ async fn receive_inner_v1(
                     "Receive file '{}' ({})?",
                     req.file_name(),
                     match NumberPrefix::binary(req.file_size() as f64) {
-                        NumberPrefix::Standalone(bytes) => format!("{} bytes", bytes),
+                        NumberPrefix::Standalone(bytes) => format!("{bytes} bytes"),
                         NumberPrefix::Prefixed(prefix, n) =>
                             format!("{:.1} {}B", n, prefix.symbol()),
                     },
@@ -1180,7 +1180,7 @@ async fn receive_inner_v2(
                 "Receive {} ({})?",
                 offer_name,
                 match NumberPrefix::binary(file_size as f64) {
-                    NumberPrefix::Standalone(bytes) => format!("{} bytes", bytes),
+                    NumberPrefix::Standalone(bytes) => format!("{bytes} bytes"),
                     NumberPrefix::Prefixed(prefix, n) =>
                         format!("{:.1} {}B in size", n, prefix.symbol()),
                 },
@@ -1278,9 +1278,9 @@ fn transit_handler(info: TransitInfo) {
     };
 
     if info.conn_type == ConnectionType::Direct {
-        let _ = writeln!(term, "Connecting {} to {}", conn_type, peer_addr);
+        let _ = writeln!(term, "Connecting {conn_type} to {peer_addr}");
     } else {
-        let _ = writeln!(term, "Connecting {}", conn_type);
+        let _ = writeln!(term, "Connecting {conn_type}");
     };
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -948,7 +948,7 @@ impl FromStr for Code {
                 let password: Password = p.parse()?;
                 let nameplate: Nameplate = n.parse()?;
 
-                Ok(Self(format!("{}-{}", nameplate, password)))
+                Ok(Self(format!("{nameplate}-{password}")))
             },
             None if s.is_empty() => Err(ParseCodeError::Empty),
             None => Err(ParseCodeError::SeparatorMissing),

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -44,7 +44,7 @@ impl Key<WormholeKey> {
      */
     #[cfg(feature = "transit")]
     pub(crate) fn derive_transit_key(&self, appid: &AppID) -> Key<crate::transit::TransitKey> {
-        let transit_purpose = format!("{}/transit-key", appid);
+        let transit_purpose = format!("{appid}/transit-key");
         let derived_key = self.derive_subkey_from_purpose(&transit_purpose);
         tracing::trace!(
             "Input key: {}, Transit key: {}, Transit purpose: '{}'",

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -66,8 +66,7 @@ impl RendezvousError {
 
     pub(self) fn invalid_message(expected: &str, got: impl std::fmt::Debug) -> Self {
         Self::protocol(format!(
-            "Unexpected message (protocol error): Expected '{}', but got: {:?}",
-            expected, got
+            "Unexpected message (protocol error): Expected '{expected}', but got: {got:?}"
         ))
     }
 
@@ -144,8 +143,7 @@ impl WsConnection {
                 },
                 Some(other) => {
                     return Err(RendezvousError::protocol(format!(
-                        "Got unexpected message type from server '{}'",
-                        other
+                        "Got unexpected message type from server '{other}'"
                     )))
                 },
                 None => continue,
@@ -187,8 +185,7 @@ impl WsConnection {
                 },
                 Some(other) => {
                     break Err(RendezvousError::protocol(format!(
-                        "Got unexpected message type from server '{}'",
-                        other
+                        "Got unexpected message type from server '{other}'"
                     )))
                 },
                 None => (/*continue*/),
@@ -367,8 +364,7 @@ impl RendezvousServer {
             InboundMessage::Welcome { welcome } => welcome,
             other => {
                 return Err(RendezvousError::protocol(format!(
-                    "First message server sends must be 'welcome', but was '{}'",
-                    other
+                    "First message server sends must be 'welcome', but was '{other}'"
                 )))
             },
         };
@@ -474,8 +470,7 @@ impl RendezvousServer {
                 }
             },
             Some(other) => Err(RendezvousError::protocol(format!(
-                "Expected message from peer, got '{}' instead",
-                other
+                "Expected message from peer, got '{other}' instead"
             ))),
             None => Ok(None),
         }

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -465,7 +465,7 @@ mod test {
         let s = r#"{"type": "ack", "id": null, "server_tx": 1234.56}"#;
         let m = serde_json::from_str(s).unwrap();
         match m {
-            InboundMessage::Ack {} => (),
+            InboundMessage::Ack => (),
             _ => panic!(),
         }
     }

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -51,10 +51,10 @@ impl std::fmt::Display for WelcomeMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "WelcomeMessage {{ ")?;
         if let Some(motd) = &self.motd {
-            write!(f, "motd: '{}', ", motd)?;
+            write!(f, "motd: '{motd}', ")?;
         }
         if let Some(permission_required) = &self.permission_required {
-            write!(f, "permission_required: '{}', ", permission_required)?;
+            write!(f, "permission_required: '{permission_required}', ")?;
         }
         write!(f, ".. }}")?;
         Ok(())

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -88,9 +88,7 @@ pub async fn test_connect_with_unknown_code_and_no_allocate_fails() {
         WormholeError::UnclaimedNameplate(nameplate) => {
             assert_eq!(nameplate, code.nameplate());
         },
-        _ => {
-            assert!(false);
-        },
+        _ => panic!("Wrong error type: {error}"),
     }
 }
 
@@ -370,7 +368,6 @@ pub async fn test_send_many() {
                 .await?,
             )
             .await?;
-            let gen_offer = gen_offer.clone();
             senders.push(async_std::task::spawn_local(async move {
                 eyre::Result::Ok(
                     crate::transfer::send(

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -177,8 +177,7 @@ async fn file_offers(
                             if self.send_bytes == self.receive_bytes {
                                 Poll::Ready(Ok(()))
                             } else {
-                                Poll::Ready(Err(io::Error::new(
-                                    io::ErrorKind::Other,
+                                Poll::Ready(Err(io::Error::other(
                                     "Send and receive are not the same",
                                 )))
                             }

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -527,7 +527,7 @@ pub async fn test_crowded() {
         ) => {
             assert_eq!(&*error, "crowded")
         },
-        other => panic!("Got wrong error message: {}, wanted 'crowded'", other),
+        other => panic!("Got wrong error message: {other}, wanted 'crowded'"),
     }
 }
 
@@ -541,10 +541,7 @@ pub async fn test_connect_with_code_expecting_nameplate() {
         magic_wormhole::WormholeError::UnclaimedNameplate(x) => {
             assert_eq!(x, code.nameplate());
         },
-        other => panic!(
-            "Got wrong error type {:?}. Expected `NameplateNotFound`",
-            other
-        ),
+        other => panic!("Got wrong error type {other:?}. Expected `NameplateNotFound`"),
     }
 }
 

--- a/src/core/wordlist.rs
+++ b/src/core/wordlist.rs
@@ -235,7 +235,7 @@ mod test {
         let more_words = vec![vec_strings("purple yellow"), vec_strings("sausages")];
 
         let expected2 = vec_strs("purple-sausages yellow-sausages");
-        let expected3 = vec![
+        let expected3 = [
             "purple-sausages-purple",
             "yellow-sausages-purple",
             "purple-sausages-yellow",

--- a/src/transfer/cancel.rs
+++ b/src/transfer/cancel.rs
@@ -175,7 +175,7 @@ pub async fn handle_run_result_noclose<T, C: Future<Output = ()>>(
                 async {
                     debug_err(
                         wormhole
-                            .send_json(&PeerMessage::Error(format!("{}", error)))
+                            .send_json(&PeerMessage::Error(format!("{error}")))
                             .await,
                         "notify peer about the error",
                     );
@@ -194,7 +194,7 @@ pub async fn handle_run_result_noclose<T, C: Future<Output = ()>>(
                 async {
                     debug_err(
                         wormhole
-                            .send_json(&PeerMessage::Error(format!("{}", cancelled)))
+                            .send_json(&PeerMessage::Error(format!("{cancelled}")))
                             .await,
                         "notify peer about our cancellation",
                     );

--- a/src/transfer/offer.rs
+++ b/src/transfer/offer.rs
@@ -41,13 +41,10 @@ impl OfferSend {
             let offer_name = offer_name
                 .to_str()
                 .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!(
-                            "{} is not UTF-8 encoded",
-                            (offer_name.as_ref() as &Path).display()
-                        ),
-                    )
+                    std::io::Error::other(format!(
+                        "{} is not UTF-8 encoded",
+                        (offer_name.as_ref() as &Path).display()
+                    ))
                 })?
                 .to_owned();
             let old = content.insert(offer_name, OfferSendEntry::new(path).await?);
@@ -291,8 +288,7 @@ impl OfferSendEntry {
         //         target: target
         //             .to_str()
         //             .ok_or_else(|| {
-        //                 std::io::Error::new(
-        //                     std::io::ErrorKind::Other,
+        //                 std::io::Error::other(
         //                     format!("{} is not UTF-8 encoded", target.display()),
         //                 )
         //             })?
@@ -311,10 +307,10 @@ impl OfferSendEntry {
                         .expect("Internal error: non-root paths should always have a name")
                         .to_str()
                         .ok_or_else(|| {
-                            std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                format!("{} is not UTF-8 encoded", path.display()),
-                            )
+                            std::io::Error::other(format!(
+                                "{} is not UTF-8 encoded",
+                                path.display()
+                            ))
                         })?
                         .to_owned();
                     let offer = new_recurse(path).await?;

--- a/src/transfer/v2.rs
+++ b/src/transfer/v2.rs
@@ -123,7 +123,7 @@ async fn make_transit(
             other => {
                 let error = TransferError::unexpected_message("transit-v2", other);
                 let _ = wormhole
-                    .send_json(&PeerMessage::Error(format!("{}", error)))
+                    .send_json(&PeerMessage::Error(format!("{error}")))
                     .await;
                 bail!(error)
             },
@@ -143,7 +143,7 @@ async fn make_transit(
         Err(error) => {
             let error = TransferError::TransitConnect(error);
             let _ = wormhole
-                .send_json(&PeerMessage::Error(format!("{}", error)))
+                .send_json(&PeerMessage::Error(format!("{error}")))
                 .await;
             return Err(error);
         },

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -651,7 +651,7 @@ impl std::fmt::Display for ConnectionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConnectionType::Direct => write!(f, "directly"),
-            ConnectionType::Relay { name: Some(name) } => write!(f, "via relay ({})", name),
+            ConnectionType::Relay { name: Some(name) } => write!(f, "via relay ({name})"),
             ConnectionType::Relay { name: None } => write!(f, "via relay"),
         }
     }


### PR DESCRIPTION
- Replace split/last and explicit indexing for host:port splitting with an `rsplit_once` and match.
- Suppress lint for use of indexed format args; someone probably thought it was more readable this way, and they might be right.
- Remove clone call for a function
- Use informative error (clippy didn't like `assert!(false)` and suggested `unreachable!()`)

All that's left after this are some "large Err" and "large enum variant size difference" lints that will require either API changes or lint suppression.